### PR TITLE
Rename Charcoal Block to Charred Log

### DIFF
--- a/src/main/resources/assets/architects_palette/lang/en_us.json
+++ b/src/main/resources/assets/architects_palette/lang/en_us.json
@@ -57,7 +57,7 @@
   "block.architects_palette.pipe": "Pipe",
   "block.architects_palette.spool": "Spool",
 
-  "block.architects_palette.charcoal_block": "Charcoal Block",
+  "block.architects_palette.charcoal_block": "Charred Log",
 
   "block.architects_palette.limestone": "Limestone",
   "block.architects_palette.limestone_bricks": "Limestone Bricks",


### PR DESCRIPTION
Main reasoning being Quark (and several other mods) already have a Charcoal Block, and it looks more like a log anyway.